### PR TITLE
Update Util.cs

### DIFF
--- a/Robots/Util.cs
+++ b/Robots/Util.cs
@@ -56,7 +56,7 @@ namespace Robots
         {
             get
             {
-                return $@"{Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)}\Robots";
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Robots");
             }
         }
 


### PR DESCRIPTION
earlier implementation was OS depended ( forward slash )
resulted in **"/Users/some_guy\Robots"** rather than **"/Users/some_guy/Robots"** on osx